### PR TITLE
Ask the user if they want to force a non-upgrade

### DIFF
--- a/brainframe/cli/commands/update.py
+++ b/brainframe/cli/commands/update.py
@@ -25,7 +25,18 @@ def update():
     existing_version = version.parse(existing_version_str)
     requested_version = version.parse(requested_version_str)
 
-    if not args.force:
+    force_non_upgrade = False
+    if args.noninteractive:
+        # Use the --force flag to decide if non-upgrades are allowed
+        force_non_upgrade = args.force
+    else:
+        # Ask the user if non-upgrades should be allowed
+        if existing_version >= requested_version:
+            force_non_upgrade = print_utils.ask_yes_no(
+                "general.ask-force-non-upgrade")
+
+    if not force_non_upgrade:
+        # Fail if the requested version is not an upgrade
         if existing_version == requested_version:
             print_utils.fail_translate(
                 "update.version-already-installed",

--- a/brainframe/cli/commands/update.py
+++ b/brainframe/cli/commands/update.py
@@ -25,18 +25,18 @@ def update():
     existing_version = version.parse(existing_version_str)
     requested_version = version.parse(requested_version_str)
 
-    force_non_upgrade = False
+    force_downgrade = False
     if args.noninteractive:
-        # Use the --force flag to decide if non-upgrades are allowed
-        force_non_upgrade = args.force
+        # Use the --force flag to decide if downgrades are allowed
+        force_downgrade = args.force
     else:
-        # Ask the user if non-upgrades should be allowed
+        # Ask the user if downgrades should be allowed
         if existing_version >= requested_version:
-            force_non_upgrade = print_utils.ask_yes_no(
-                "general.ask-force-non-upgrade"
+            force_downgrade = print_utils.ask_yes_no(
+                "update.ask-force-downgrade"
             )
 
-    if not force_non_upgrade:
+    if not force_downgrade:
         # Fail if the requested version is not an upgrade
         if existing_version == requested_version:
             print_utils.fail_translate(

--- a/brainframe/cli/commands/update.py
+++ b/brainframe/cli/commands/update.py
@@ -33,7 +33,8 @@ def update():
         # Ask the user if non-upgrades should be allowed
         if existing_version >= requested_version:
             force_non_upgrade = print_utils.ask_yes_no(
-                "general.ask-force-non-upgrade")
+                "general.ask-force-non-upgrade"
+            )
 
     if not force_non_upgrade:
         # Fail if the requested version is not an upgrade

--- a/brainframe/cli/translations/update.en.yml
+++ b/brainframe/cli/translations/update.en.yml
@@ -20,3 +20,7 @@ en:
   than the currently installed version, BrainFrame:%{existing_version}. We
   don't recommend downgrading BrainFrame for data integrity reasons. This
   request will be ignored. You can force a downgrade using the --force flag."
+  ask-force-non-upgrade: "BrainFrame:%{requested_version} does not appear to
+  be a newer version then the current version, BrainFrame:%{existing_version}.
+  Downgrading BrainFrame is not officially supported and may lead to data loss.
+  Are you sure you want to continue?"

--- a/brainframe/cli/translations/update.en.yml
+++ b/brainframe/cli/translations/update.en.yml
@@ -20,7 +20,7 @@ en:
   than the currently installed version, BrainFrame:%{existing_version}. We
   don't recommend downgrading BrainFrame for data integrity reasons. This
   request will be ignored. You can force a downgrade using the --force flag."
-  ask-force-non-upgrade: "BrainFrame:%{requested_version} does not appear to
+  ask-force-downgrade: "BrainFrame:%{requested_version} does not appear to
   be a newer version then the current version, BrainFrame:%{existing_version}.
   Downgrading BrainFrame is not officially supported and may lead to data loss.
   Are you sure you want to continue?"


### PR DESCRIPTION
Prompts the user asking if they want to force a non-upgrade if they're in interactive mode, instead of requiring the `--force` flag.

Fixes #16.